### PR TITLE
Add gremlin token type T and support to token properties

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -44,6 +44,17 @@ type ValueWithID struct {
 
 type VertexPropertyMap map[string][]ValueWithID
 
+// T defines gremlin Tokens
+type T string
+
+const (
+	TId T = "id"
+	TLabel T = "label"
+	TKey = "key"
+	TValue = "value"
+)
+
+
 // Type defines the cosmos db complex types
 type Type string
 


### PR DESCRIPTION
_[draft PR simply to save some explorations]_

Adds the type `T` to enumerate gremlin tokens and adds support for them in `toKeyValueString()` method, allowing the output to skip quotes when its key is of type `T`

Usage:
```go
  query.Property(TId, "id-value")
  // generates .Property(id, "id-value")

  query.Property(TLabel, "label-value")
  // generates .Property(label, "label-value")
```