### PR TITLE
Add TrustedStringValue type to avoid unwanted escape string

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"fmt"
-
+	
 	"github.com/spf13/cast"
+	"github.com/supplyon/gremcos/interfaces"
 )
 
 // Property represents the cosmos db type for a property.
@@ -119,6 +120,10 @@ func (tv TypedValue) AsStringE() (string, error) {
 
 func (tv TypedValue) AsString() string {
 	return UnEscape(cast.ToString(tv.Value))
+}
+
+func (tv TypedValue) AsTrustedStringValue() interfaces.TrustedStringValue {
+	return interfaces.TrustedStringValue(cast.ToString(tv.Value))
 }
 
 func (tv TypedValue) String() string {

--- a/api/vertex.go
+++ b/api/vertex.go
@@ -331,6 +331,8 @@ func toKeyValueString(key, value interface{}) (string, error) {
 	switch casted := value.(type) {
 	case *simpleQueryBuilder:
 		return fmt.Sprintf("(\"%s\",%s)", key, casted.String()), nil
+	case interfaces.TrustedStringValue:
+		return fmt.Sprintf("(\"%s\",\"%s\")", key, casted), nil
 	case string:
 		return fmt.Sprintf("(\"%s\",\"%s\")", key, Escape(casted)), nil
 	case bool:

--- a/interfaces/querybuilder.go
+++ b/interfaces/querybuilder.go
@@ -2,6 +2,9 @@ package interfaces
 
 import "github.com/gofrs/uuid"
 
+// Type used to avoid escaping strings with special characters when building a query string
+type TrustedStringValue string
+
 type Order string
 
 const (


### PR DESCRIPTION
_[draft PR simply to save some explorations]_

Adds type `TrustedStringValue` to support strings that shouldn't be escaped, even when they include especial characters, like cosmos `_etag` values.

Usage:
```go
  trustedValue := interfaces.TrustedStringValue("\"a203309e-0000-0100-0000-631224db0000\"")
  query.Property("ETag", trustedValue)
  // generates:
  //   .property("ETag", "\"a203309e-0000-0100-0000-631224db0000\"")
  // instead of:
  //   .property("ETag", "%22a203309e-0000-0100-0000-631224db0000%22")
```